### PR TITLE
Requiring date because it's not part of core

### DIFF
--- a/twitch.gemspec
+++ b/twitch.gemspec
@@ -3,7 +3,6 @@ $:.push File.expand_path("../lib", __FILE__)
 require "date"
 require "twitch/version"
 
-
 Gem::Specification.new do |s|
   s.name        = 'twitch'
   s.version     = Twitch::VERSION::STRING

--- a/twitch.gemspec
+++ b/twitch.gemspec
@@ -1,6 +1,8 @@
 $:.push File.expand_path("../lib", __FILE__)
 
+require "date"
 require "twitch/version"
+
 
 Gem::Specification.new do |s|
   s.name        = 'twitch'


### PR DESCRIPTION
I ran a 'bundle outdated' and this gem blew up because it 'date' wasn't required.